### PR TITLE
init database

### DIFF
--- a/server/src/main/java/org/hl7/davinci/endpoint/rems/DatabaseInit.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/rems/DatabaseInit.java
@@ -1,0 +1,67 @@
+package org.hl7.davinci.endpoint.rems;
+
+import ca.uhn.fhir.parser.IParser;
+import org.hl7.davinci.endpoint.rems.database.drugs.Drug;
+import org.hl7.davinci.endpoint.rems.database.drugs.DrugsRepository;
+import org.hl7.davinci.endpoint.rems.database.fhir.RemsFhir;
+import org.hl7.davinci.endpoint.rems.database.fhir.RemsFhirRepository;
+import org.hl7.davinci.endpoint.rems.database.requirement.Requirement;
+import org.hl7.davinci.endpoint.rems.database.requirement.RequirementRepository;
+import org.hl7.davinci.r4.FhirComponents;
+import org.hl7.fhir.r4.model.ResourceType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+@Configuration
+class DatabaseInit {
+
+    private static final Logger log = LoggerFactory.getLogger(DatabaseInit.class);
+
+    static String readFile(String path, Charset encoding)
+            throws IOException
+    {
+        System.out.println(Paths.get(path).toAbsolutePath());
+
+        byte[] encoded = Files.readAllBytes(Paths.get(path));
+        return new String(encoded, encoding);
+    }
+
+
+    @Bean
+    CommandLineRunner initDatabase(DrugsRepository repository, RemsFhirRepository remsFhirRepository, RequirementRepository requirementRepository) {
+        FhirComponents fhirComponents = new FhirComponents();
+        IParser jsonParser = fhirComponents.getJsonParser();
+
+        return args -> {
+            log.info("Preloading turalio");
+            Drug turalio = new Drug();
+
+            String questionnaire = readFile("src/main/java/org/hl7/davinci/endpoint/rems/resources/Turalio/fhir/Questionnaire-R4-DrugHasREMS.json", Charset.defaultCharset());
+            Requirement requirement = new Requirement();
+            RemsFhir remsFhir = new RemsFhir();
+            remsFhir.setResourceType(ResourceType.Questionnaire.toString());
+            remsFhir.setResource(questionnaire);
+            remsFhir.setId("q1");
+            remsFhirRepository.save(remsFhir);
+            requirement.setRequirement(remsFhir);
+            requirement.setDescription("complete questionnaire");
+            turalio.addRequirement(requirement);
+            turalio.setId("turalio");
+            repository.save(turalio);
+            requirement.setDrug(turalio);
+            requirementRepository.save(requirement);
+
+
+//
+//            log.info("Preloading " + repository.save(new RemsFhir()));
+        };
+    }
+}

--- a/server/src/main/java/org/hl7/davinci/endpoint/rems/RemsServer.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/rems/RemsServer.java
@@ -1,0 +1,31 @@
+package org.hl7.davinci.endpoint.rems;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.server.RestfulServer;
+import ca.uhn.fhir.rest.server.interceptor.ResponseHighlighterInterceptor;
+import org.hl7.davinci.endpoint.rems.providers.QuestionnaireProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@WebServlet("/rems/fhir/*")
+public class RemsServer extends RestfulServer {
+
+
+    @Autowired
+    QuestionnaireProvider questionnaireProvider;
+
+    @Override
+    protected void initialize() throws ServletException {
+        // Create a context for the appropriate version
+        setFhirContext(FhirContext.forR4());
+
+        // Register resource providers
+        registerProvider(questionnaireProvider);
+
+        // Format the responses in nice HTML
+        registerInterceptor(new ResponseHighlighterInterceptor());
+
+    }
+}

--- a/server/src/main/java/org/hl7/davinci/endpoint/rems/controller/RemsController.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/rems/controller/RemsController.java
@@ -1,0 +1,49 @@
+package org.hl7.davinci.endpoint.rems.controller;
+
+import javassist.NotFoundException;
+import org.hl7.davinci.endpoint.Application;
+import org.hl7.davinci.endpoint.files.FileResource;
+import org.hl7.davinci.endpoint.rems.database.drugs.Drug;
+import org.hl7.davinci.endpoint.rems.database.drugs.DrugsRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.Resource;
+import org.springframework.data.crossstore.ChangeSetPersister;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.logging.Logger;
+
+/**
+ * Provides the REST interface that can be interacted with at [base]/api/fhir and [base]/fhir.
+ */
+@RestController
+public class RemsController {
+    private static Logger logger = Logger.getLogger(Application.class.getName());
+
+    @Autowired
+    private DrugsRepository drugsRepository;
+
+    @GetMapping(value = "/rems/{id}")
+    @CrossOrigin
+    public ResponseEntity<Drug> getRequirments(HttpServletRequest request, @PathVariable String id) throws IOException {
+        Drug drug = drugsRepository.findById(id).get();
+        return processRequirements(drug);
+    }
+
+    private ResponseEntity<Drug> processRequirements(Drug drug) {
+        if (drug == null) {
+            logger.warning("drug not found, return error (404)");
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType(MediaType.APPLICATION_JSON_VALUE))
+                .body(drug);
+    }
+}

--- a/server/src/main/java/org/hl7/davinci/endpoint/rems/database/drugs/Drug.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/rems/database/drugs/Drug.java
@@ -1,0 +1,63 @@
+package org.hl7.davinci.endpoint.rems.database.drugs;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.hl7.davinci.endpoint.rems.database.mapping.StringListConverter;
+import org.hl7.davinci.endpoint.rems.database.requirement.Requirement;
+
+import javax.persistence.*;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "drug")
+public class Drug {
+    @Id
+    @Column(name = "id", nullable = false)
+    private String id;
+
+    @Column(name = "codeSystem", nullable = true)
+    private String codeSystem;
+
+    @Column(name = "code", nullable = true)
+    private String code;
+
+    @Column(name = "timestamp", nullable = false)
+    private String timestamp;
+
+    @OneToMany(mappedBy="drug")
+    private List<Requirement> requirements = new ArrayList<>();
+
+    public Drug() {
+        this.timestamp = ZonedDateTime.now().format(DateTimeFormatter.ofPattern( "uuuu.MM.dd.HH.mm.ss" ));
+
+    }
+
+    public String getId() {
+        return this.id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public List<Requirement> getRequirements() {
+        return this.requirements;
+    }
+
+    public void setResource(List<Requirement> requirements) {
+        this.requirements = requirements;
+    }
+
+    public void addRequirement(Requirement requirement)  {
+        this.requirements.add(requirement);
+    }
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+}

--- a/server/src/main/java/org/hl7/davinci/endpoint/rems/database/drugs/DrugsRepository.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/rems/database/drugs/DrugsRepository.java
@@ -1,0 +1,24 @@
+package org.hl7.davinci.endpoint.rems.database.drugs;
+
+import java.util.List;
+
+import org.hl7.davinci.endpoint.rems.database.fhir.RemsFhir;
+import org.hl7.fhir.r4.model.IdType;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.bind.annotation.CrossOrigin;
+
+
+@RepositoryRestResource
+@CrossOrigin(origins = "http://localhost:4200")
+@Repository
+public interface DrugsRepository extends CrudRepository<Drug, String> {
+
+    @Query(
+            "SELECT r FROM Drug r")
+    List<Drug> findLogs();
+
+}
+

--- a/server/src/main/java/org/hl7/davinci/endpoint/rems/database/fhir/RemsFhir.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/rems/database/fhir/RemsFhir.java
@@ -1,0 +1,60 @@
+package org.hl7.davinci.endpoint.rems.database.fhir;
+
+import javax.persistence.*;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Entity
+@Table(name = "rems_fhir")
+public class RemsFhir {
+    @Id
+    @Column(name = "id", nullable = false)
+    private String id;
+
+    @Column(name = "resourceType", nullable = false)
+    private String resourceType;
+
+    @Column(name = "timestamp", nullable = false)
+    private String timestamp;
+
+    @Lob
+    @Column(name = "resource", nullable = false)
+    private String resource;
+
+    public RemsFhir() {
+        this.timestamp = ZonedDateTime.now().format(DateTimeFormatter.ofPattern( "uuuu.MM.dd.HH.mm.ss" ));
+
+    }
+
+    public String getId() {
+        return this.id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getResource() {
+        return this.resource;
+    }
+
+    public void setResource(String resource) {
+        this.resource = resource;
+    }
+
+    public String getResourceType() {
+        return resourceType;
+    }
+
+    public void setResourceType(String resourceType) {
+        this.resourceType = resourceType;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+}

--- a/server/src/main/java/org/hl7/davinci/endpoint/rems/database/fhir/RemsFhirImpl.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/rems/database/fhir/RemsFhirImpl.java
@@ -1,0 +1,56 @@
+package org.hl7.davinci.endpoint.rems.database.fhir;
+
+import org.hl7.fhir.r4.model.IdType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+
+
+/**
+ * Defines the operations that the fhir server can provide
+ */
+@Service
+@Primary
+public class RemsFhirImpl implements RemsFhirService {
+    static final Logger logger = LoggerFactory.getLogger(org.hl7.davinci.endpoint.rems.database.fhir.RemsFhirImpl.class);
+
+    @Autowired
+    private RemsFhirRepository fhirRepository;
+
+    @Override
+    public Iterable<RemsFhir> findAll() {
+        return this.fhirRepository.findAll();
+    }
+
+    @Override
+    public RemsFhir findById(String id) {
+        return this.fhirRepository.findById(id).get();
+    }
+
+    @Override
+    public RemsFhir create(RemsFhir resource) {
+        return this.fhirRepository.save(resource);
+    }
+
+    @Override
+    public RemsFhir edit(RemsFhir resource) {
+        return this.fhirRepository.save(resource);
+    }
+
+    @Override
+    public void deleteById(String id) {
+        this.fhirRepository.deleteById(id);
+    }
+
+    @Override
+    public void logAll() {
+        Iterable<RemsFhir> fullLog = findAll();
+        for (RemsFhir entry : fullLog) {
+            logger.info("fhir server entry: " + entry.toString());
+        }
+    }
+
+}

--- a/server/src/main/java/org/hl7/davinci/endpoint/rems/database/fhir/RemsFhirRepository.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/rems/database/fhir/RemsFhirRepository.java
@@ -1,0 +1,24 @@
+package org.hl7.davinci.endpoint.rems.database.fhir;
+
+import java.util.List;
+
+import org.hl7.fhir.r4.model.IdType;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.bind.annotation.CrossOrigin;
+
+
+@RepositoryRestResource
+@CrossOrigin(origins = "http://localhost:4200")
+@Repository
+public interface RemsFhirRepository extends CrudRepository<RemsFhir, String> {
+
+    @Query(
+            "SELECT r FROM RemsFhir r")
+    List<RemsFhir> findLogs();
+
+}
+
+

--- a/server/src/main/java/org/hl7/davinci/endpoint/rems/database/fhir/RemsFhirService.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/rems/database/fhir/RemsFhirService.java
@@ -1,0 +1,21 @@
+package org.hl7.davinci.endpoint.rems.database.fhir;
+
+import ca.uhn.fhir.model.api.IResource;
+import org.hl7.fhir.r4.model.IdType;
+
+/**
+ * Outlines which methods the database will support.
+ */
+public interface RemsFhirService {
+    Iterable<RemsFhir> findAll();
+
+    RemsFhir findById(String id);
+
+    RemsFhir create(RemsFhir resource);
+
+    RemsFhir edit(RemsFhir resource);
+
+    void deleteById(String id);
+
+    void logAll();
+}

--- a/server/src/main/java/org/hl7/davinci/endpoint/rems/database/requirement/Requirement.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/rems/database/requirement/Requirement.java
@@ -1,0 +1,83 @@
+package org.hl7.davinci.endpoint.rems.database.requirement;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.hl7.davinci.endpoint.rems.database.drugs.Drug;
+import org.hl7.davinci.endpoint.rems.database.fhir.RemsFhir;
+
+import javax.persistence.*;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Entity
+@Table(name = "requirement")
+public class Requirement {
+    @Id
+    @GeneratedValue
+    @Column(name = "id", nullable = false)
+    private Integer id;
+
+    @Column(name = "timestamp", nullable = false)
+    private String timestamp;
+
+    @Column(name = "completed", nullable = false)
+    private boolean completed ;
+
+    @Column(name = "description", nullable = true)
+    private String description;
+
+    // this should be a reference to a FHIR resource
+    @JoinColumn(name = "requirement", nullable = false)
+    @OneToOne
+    private RemsFhir requirement;
+
+    @ManyToOne
+    @JoinColumn(name="DRUG_ID")
+    @JsonIgnore
+    private Drug drug;
+
+    public Requirement() {
+        this.timestamp = ZonedDateTime.now().format(DateTimeFormatter.ofPattern( "uuuu.MM.dd.HH.mm.ss" ));
+        this.completed = false;
+    }
+
+    public RemsFhir getRequirement() {
+        return this.requirement;
+    }
+
+    public void setRequirement(RemsFhir requirement) {
+        this.requirement = requirement;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public boolean isCompleted() {
+        return completed;
+    }
+
+    public void setCompleted(boolean completed) {
+        this.completed = completed;
+    }
+
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Drug getDrug() {
+        return drug;
+    }
+
+    public void setDrug(Drug drug) {
+        this.drug = drug;
+    }
+
+}

--- a/server/src/main/java/org/hl7/davinci/endpoint/rems/database/requirement/RequirementRepository.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/rems/database/requirement/RequirementRepository.java
@@ -1,0 +1,23 @@
+package org.hl7.davinci.endpoint.rems.database.requirement;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.bind.annotation.CrossOrigin;
+
+
+@RepositoryRestResource
+@CrossOrigin(origins = "http://localhost:4200")
+@Repository
+public interface RequirementRepository extends CrudRepository<Requirement, String> {
+
+    @Query(
+            "SELECT r FROM Requirement r")
+    List<Requirement> findAll();
+
+}
+
+

--- a/server/src/main/java/org/hl7/davinci/endpoint/rems/providers/QuestionnaireProvider.java
+++ b/server/src/main/java/org/hl7/davinci/endpoint/rems/providers/QuestionnaireProvider.java
@@ -1,0 +1,73 @@
+package org.hl7.davinci.endpoint.rems.providers;
+
+import ca.uhn.fhir.parser.IParser;
+import ca.uhn.fhir.rest.annotation.Create;
+import ca.uhn.fhir.rest.annotation.IdParam;
+import ca.uhn.fhir.rest.annotation.Read;
+import ca.uhn.fhir.rest.annotation.ResourceParam;
+import ca.uhn.fhir.rest.api.MethodOutcome;
+import ca.uhn.fhir.rest.server.IResourceProvider;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import org.hl7.davinci.endpoint.rems.database.fhir.RemsFhir;
+import org.hl7.davinci.endpoint.rems.database.fhir.RemsFhirRepository;
+import org.hl7.davinci.r4.FhirComponents;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Questionnaire;
+import org.hl7.fhir.r4.model.ResourceType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+@Component
+public class QuestionnaireProvider implements IResourceProvider {
+    /**
+     * Constructor
+     */
+
+    @Autowired
+    RemsFhirRepository remsFhirRepository;
+
+    IParser jsonParser;
+
+    public QuestionnaireProvider() {
+        FhirComponents fhirComponents = new FhirComponents();
+        jsonParser = fhirComponents.getJsonParser();
+    }
+
+    @Override
+    public Class<? extends IBaseResource> getResourceType() {
+        return Questionnaire.class;
+    }
+
+    /**
+     * Simple implementation of the "read" method
+     */
+    @Read()
+    public Questionnaire read(@IdParam IdType theId) {
+        RemsFhir retVal = remsFhirRepository.findById(theId.getIdPart()).get();
+        if (retVal == null) {
+            throw new ResourceNotFoundException(theId);
+        }
+        return (Questionnaire) jsonParser.parseResource(retVal.getResource());
+    }
+
+    @Create
+    public MethodOutcome createQuestionnaire(@ResourceParam Questionnaire theQuestionnaire) {
+        RemsFhir resource = new RemsFhir();
+        resource.setResourceType(ResourceType.Questionnaire.toString());
+        String uuid = UUID.randomUUID().toString();
+        theQuestionnaire.setId(uuid);
+        resource.setId(uuid);
+        resource.setResource(jsonParser.encodeResourceToString(theQuestionnaire));
+        remsFhirRepository.save(resource);
+        MethodOutcome methodOutcome = new MethodOutcome();
+        methodOutcome.setResource(theQuestionnaire);
+        return methodOutcome;
+    }
+
+}

--- a/server/src/main/java/org/hl7/davinci/endpoint/rems/resources/Turalio/fhir/Questionnaire-R4-DrugHasREMS.json
+++ b/server/src/main/java/org/hl7/davinci/endpoint/rems/resources/Turalio/fhir/Questionnaire-R4-DrugHasREMS.json
@@ -1,0 +1,1177 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "TuralioRemsPatientEnrollment",
+  "name": "TuralioRemsPatientEnrollment",
+  "title": "Turalio Rems Patient Enrollment",
+  "status": "draft",
+  "subjectType": [
+    "Patient"
+  ],
+  "date": "2020-05-20",
+  "publisher": "Da Vinci DTR",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/cqf-library",
+      "valueCanonical": "http://hl7.org/fhir/us/davinci-dtr/Library/DrugHasREMS-prepopulation"
+    }
+  ],
+  "item": [
+    {
+      "linkId": "1",
+      "type": "group",
+      "text": "Patient Information",
+      "item": [
+        {
+          "linkId": "1.1",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/sub-questionnaire",
+              "valueCanonical": "questionnaire/patient-info-base"
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/sub-questionnaire-expand",
+              "valueBoolean": true
+            }
+          ],
+          "type": "display"
+        },
+        {
+          "linkId": "1.2",
+          "text": "Address Line 1",
+          "type": "string",
+          "required": false,
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+              "valueExpression": {
+                "language": "text/cql",
+                "expression": "\"BasicPatientInfoPrepopulation\".Line"
+              }
+            }
+          ]
+        },
+        {
+          "linkId": "1.3",
+          "text": "Address Line 2",
+          "type": "string",
+          "required": false
+        },
+        {
+          "linkId": "1.4",
+          "text": "City",
+          "type": "string",
+          "required": false,
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+              "valueExpression": {
+                "language": "text/cql",
+                "expression": "\"BasicPatientInfoPrepopulation\".City"
+              }
+            }
+          ]
+        },
+        {
+          "linkId": "1.5",
+          "text": "State",
+          "type": "string",
+          "required": false,
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+              "valueExpression": {
+                "language": "text/cql",
+                "expression": "\"BasicPatientInfoPrepopulation\".State"
+              }
+            }
+          ]
+        },
+        {
+          "linkId": "1.6",
+          "text": "Zip",
+          "type": "string",
+          "required": false,
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+              "valueExpression": {
+                "language": "text/cql",
+                "expression": "\"BasicPatientInfoPrepopulation\".Zip"
+              }
+            }
+          ]
+        },
+        {
+          "linkId": "1.7",
+          "text": "Telephone",
+          "type": "string",
+          "required": false,
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+              "valueExpression": {
+                "language": "text/cql",
+                "expression": "\"BasicPatientInfoPrepopulation\".Phone"
+              }
+            }
+          ]
+        },
+        {
+          "linkId": "1.8",
+          "text": "Email",
+          "type": "string",
+          "required": false,
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+              "valueExpression": {
+                "language": "text/cql",
+                "expression": "\"BasicPatientInfoPrepopulation\".Email"
+              }
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+              "valueCoding": {
+                "display": "lbs"
+              }
+            },
+            {
+              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+              "valueExpression": {
+                "language": "text/cql",
+                "expression": "\"DrugHasREMSPrepopulation\".LatestWeightResult"
+              }
+            }
+          ],
+          "linkId": "1.9",
+          "code": [
+            {
+              "code": "29463-7",
+              "display": "Body weight",
+              "system": "http://loinc.org"
+            }
+          ],
+          "type": "decimal",
+          "text": "Body weight"
+        },
+        {
+          "linkId": "1.10",
+          "type": "group",
+          "text": "Body height",
+          "code": [
+            {
+              "code": "8302-2",
+              "display": "Body height",
+              "system": "http://loinc.org"
+            }
+          ],
+          "item": [
+            {
+              "type": "decimal",
+              "linkId": "1.10.1",
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                  "valueCoding": {
+                    "display": "ft"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "decimal",
+              "linkId": "1.10.2",
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                  "valueCoding": {
+                    "display": "in"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "linkId": "1.11",
+          "text": "Race",
+          "type": "open-choice",
+          "answerOption": [
+            {
+              "valueCoding": {
+                "code": "American Indian or Alaskan Native",
+                "display": "American Indian or Alaskan Native"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "Asian",
+                "display": "Asian"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "Black or African American",
+                "display": "Black or African American"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "Native Hawaiian or Other Pacific Islander",
+                "display": "Native Hawaiian or Other Pacific Islander"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "White",
+                "display": "White"
+              }
+            }            
+          ]
+        },
+        {
+          "linkId": "1.12",
+          "text": "Is the patient currently taking pexidartinib (i.e., started prior to REMS enrollment)?",
+          "type": "boolean",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+              "valueExpression": {
+                "language": "text/cql",
+                "expression": "\"DrugHasREMSPrepopulation\".TakingTuralio"
+              }
+            }
+          ],
+          "required": false,
+          "item": [
+            {
+              "type": "date",
+              "linkId": "1.12.1",
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"DrugHasREMSPrepopulation\".TuralioDate"
+                  }
+                }
+              ],
+              "text": "If yes: When did patient start pexidartinib? Date (MM/DD/YYYY):",
+              "enableWhen": [
+                {
+                  "question": "1.12",
+                  "operator": "=",
+                  "answerBoolean": true
+                }
+              ]
+            },
+            {
+              "type": "boolean",
+              "linkId": "1.12.2",
+              "text": "If yes: Was this part of a clinical study?",
+              "enableWhen": [
+                {
+                  "question": "1.12",
+                  "operator": "=",
+                  "answerBoolean": true
+                }
+              ],
+              "item": [
+                {
+                  "type": "string",
+                  "linkId": "1.12.3",
+                  "text": "Study Number",
+                  "enableWhen": [
+                    {
+                      "question": "1.12.2",
+                      "operator": "=",
+                      "answerBoolean": true
+                    }
+                  ]
+                },
+                {
+                  "type": "string",
+                  "linkId": "1.12.4",
+                  "text": "Subject ID",
+                  "enableWhen": [
+                    {
+                      "question": "1.12.2",
+                      "operator": "=",
+                      "answerBoolean": true
+                    }
+                  ]
+                },
+                {
+                  "type": "string",
+                  "linkId": "1.12.5",
+                  "text": "Comment"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "linkId": "2",
+      "type": "group",
+      "text": "Prescriber Information",
+      "item": [
+        {
+          "linkId": "2.1",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/sub-questionnaire",
+              "valueCanonical": "questionnaire/practitioner-info-base"
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/sub-questionnaire-expand",
+              "valueBoolean": true
+            }
+          ],
+          "type": "display"
+        },
+        {
+          "linkId": "2.2",
+          "text": "Practice/Facility Name (where you see this patient)",
+          "type": "string",
+          "required": false
+        },
+        {
+          "linkId": "2.3",
+          "text": "Address Line 1",
+          "type": "string",
+          "required": false,
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+              "valueExpression": {
+                "language": "text/cql",
+                "expression": "\"BasicPractitionerInfoPrepopulation\".Line"
+              }
+            }
+          ]
+        },
+        {
+          "linkId": "2.4",
+          "text": "Address Line 2",
+          "type": "string",
+          "required": false
+        },
+        {
+          "linkId": "2.5",
+          "text": "City",
+          "type": "string",
+          "required": false,
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+              "valueExpression": {
+                "language": "text/cql",
+                "expression": "\"BasicPractitionerInfoPrepopulation\".City"
+              }
+            }
+          ]
+        },
+        {
+          "linkId": "2.6",
+          "text": "State",
+          "type": "string",
+          "required": false,
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+              "valueExpression": {
+                "language": "text/cql",
+                "expression": "\"BasicPractitionerInfoPrepopulation\".State"
+              }
+            }
+          ]
+        },
+        {
+          "linkId": "2.7",
+          "text": "Zip",
+          "type": "string",
+          "required": false,
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+              "valueExpression": {
+                "language": "text/cql",
+                "expression": "\"BasicPractitionerInfoPrepopulation\".Zip"
+              }
+            }
+          ]
+        },
+        {
+          "linkId": "2.8",
+          "text": "Telephone",
+          "type": "string",
+          "required": false,
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+              "valueExpression": {
+                "language": "text/cql",
+                "expression": "\"BasicPractitionerInfoPrepopulation\".Phone"
+              }
+            }
+          ]
+        },
+        {
+          "linkId": "2.9",
+          "text": "Email",
+          "type": "string",
+          "required": false,
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+              "valueExpression": {
+                "language": "text/cql",
+                "expression": "\"BasicPractitionerInfoPrepopulation\".Email"
+              }
+            }
+          ]
+        },
+        {
+          "text": "Please visit www.turaliorems.com or contact the TURALIO REMS Coordinating Center at 1-833-TURALIO (833-887-2546) to designate up to two additional REMS certified prescribers who can view, edit, and submit REMS paperwork for your TURALIO patients.",
+          "type": "display",
+          "linkId": "2.10"
+        }
+      ]
+    },
+    {
+      "linkId": "3",
+      "type": "group",
+      "text": "Baseline Labs",
+      "item": [
+        {
+          "linkId": "3.1",
+          "text": "Assess the patient by obtaining liver tests as stated in the Prescribing Information. If Albumin or PT/INR were not obtained, indicate “not applicable.” Please provide the results below.",
+          "type": "group",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                    "code": "gtable"
+                  }
+                ]
+              }
+            }
+          ],
+          "item" : [
+            {
+              "linkId": "3.1.1",
+              "text": "Laboratory Test",
+              "type": "string",
+              "initial": [{
+                "valueString": "AST or SGOT"
+              }],
+              "readOnly": true
+            },
+            {
+              "linkId": "3.1.2",
+              "text": "Baseline Value (units, reference range)",
+              "type": "string",
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"DrugHasREMSPrepopulation\".ASTResult"
+                  }
+                }
+              ]
+            },
+            {
+              "linkId": "3.1.3",
+              "text": "Date",
+              "type": "date",
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"DrugHasREMSPrepopulation\".ASTDate"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "linkId": "3.1",
+          "type": "group",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                    "code": "gtable"
+                  }
+                ]
+              }
+            }
+          ],
+          "item" : [
+            {
+              "linkId": "3.1.1",
+              "text": "Laboratory Test",
+              "type": "string",
+              "initial": [{
+                "valueString": "ALT or SGPT"
+              }],
+              "readOnly": true
+            },
+            {
+              "linkId": "3.1.2",
+              "text": "Baseline Value (units, reference range)",
+              "type": "string",
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"DrugHasREMSPrepopulation\".ALTResult"
+                  }
+                }
+              ]
+            },
+            {
+              "linkId": "3.1.3",
+              "text": "Date",
+              "type": "date",
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"DrugHasREMSPrepopulation\".ALTDate"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "linkId": "3.1",
+          "type": "group",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                    "code": "gtable"
+                  }
+                ]
+              }
+            }
+          ],
+          "item" : [
+            {
+              "linkId": "3.1.1",
+              "text": "Laboratory Test",
+              "type": "string",
+              "initial": [{
+                "valueString": "GGT"
+              }],
+              "readOnly": true
+            },
+            {
+              "linkId": "3.1.2",
+              "text": "Baseline Value (units, reference range)",
+              "type": "string",
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"DrugHasREMSPrepopulation\".GGTResult"
+                  }
+                }
+              ]
+            },
+            {
+              "linkId": "3.1.3",
+              "text": "Date",
+              "type": "date",
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"DrugHasREMSPrepopulation\".GGTDate"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "linkId": "3.1",
+          "type": "group",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                    "code": "gtable"
+                  }
+                ]
+              }
+            }
+          ],
+          "item" : [
+            {
+              "linkId": "3.1.1",
+              "text": "Laboratory Test",
+              "type": "string",
+              "initial": [{
+                "valueString": "Total Bilirubin"
+              }],
+              "readOnly": true
+            },
+            {
+              "linkId": "3.1.2",
+              "text": "Baseline Value (units, reference range)",
+              "type": "string",
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"DrugHasREMSPrepopulation\".TotalBilirubinResult"
+                  }
+                }
+              ]
+            },
+            {
+              "linkId": "3.1.3",
+              "text": "Date",
+              "type": "date",
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"DrugHasREMSPrepopulation\".TotalBilirubinDate"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "linkId": "3.1",
+          "type": "group",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                    "code": "gtable"
+                  }
+                ]
+              }
+            }
+          ],
+          "item" : [
+            {
+              "linkId": "3.1.1",
+              "text": "Laboratory Test",
+              "type": "string",
+              "initial": [{
+                "valueString": "Direct Bilirubin"
+              }],
+              "readOnly": true
+            },
+            {
+              "linkId": "3.1.2",
+              "text": "Baseline Value (units, reference range)",
+              "type": "string",
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"DrugHasREMSPrepopulation\".DirectBilirubinResult"
+                  }
+                }
+              ]
+            },
+            {
+              "linkId": "3.1.3",
+              "text": "Date",
+              "type": "date",
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"DrugHasREMSPrepopulation\".DirectBilirubinDate"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "linkId": "3.1",
+          "type": "group",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                    "code": "gtable"
+                  }
+                ]
+              }
+            }
+          ],
+          "item" : [
+            {
+              "linkId": "3.1.1",
+              "text": "Laboratory Test",
+              "type": "string",
+              "initial": [{
+                "valueString": "Alkaline Phosphatase"
+              }],
+              "readOnly": true
+            },
+            {
+              "linkId": "3.1.2",
+              "text": "Baseline Value (units, reference range)",
+              "type": "string",
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"DrugHasREMSPrepopulation\".ALPResult"
+                  }
+                }
+              ]
+            },
+            {
+              "linkId": "3.1.3",
+              "text": "Date",
+              "type": "date",
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"DrugHasREMSPrepopulation\".ALPDate"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "linkId": "3.1",
+          "type": "group",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                    "code": "gtable"
+                  }
+                ]
+              }
+            }
+          ],
+          "item" : [
+            {
+              "linkId": "3.1.1",
+              "text": "Laboratory Test",
+              "type": "string",
+              "initial": [{
+                "valueString": "Albumin"
+              }],
+              "readOnly": true
+            },
+            {
+              "linkId": "3.1.2",
+              "text": "Baseline Value (units, reference range)",
+              "type": "string",
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"DrugHasREMSPrepopulation\".AlbuminResult"
+                  }
+                }
+              ]
+            },
+            {
+              "linkId": "3.1.3",
+              "text": "Date",
+              "type": "date",
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"DrugHasREMSPrepopulation\".AlbuminDate"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "linkId": "3.1",
+          "type": "group",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                    "code": "gtable"
+                  }
+                ]
+              }
+            }
+          ],
+          "item" : [
+            {
+              "linkId": "3.1.1",
+              "text": "Laboratory Test",
+              "type": "string",
+              "initial": [{
+                "valueString": "PT/INR"
+              }],
+              "readOnly": true
+            },
+            {
+              "linkId": "3.1.2",
+              "text": "Baseline Value (units, reference range)",
+              "type": "string",
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"DrugHasREMSPrepopulation\".PTResult"
+                  }
+                }
+              ]
+            },
+            {
+              "linkId": "3.1.3",
+              "text": "Date",
+              "type": "date",
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"DrugHasREMSPrepopulation\".PTDate"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "linkId": "4",
+      "type": "group",
+      "text": "Current Medication (including prescription, non-prescription and herbal or dietary supplements)",
+      "item": [
+        {
+          "linkId": "4.1",
+          "text": "Check box if there are no current medications",
+          "type": "boolean",
+          "required": false,
+          "initial": {
+            "value": false
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+              "valueExpression": {
+                "language": "text/cql",
+                "expression": "\"DrugHasREMSPrepopulation\".TakingMeds"
+              }
+            }
+          ]
+        },
+        {
+          "linkId": "4.2",
+          "text": "Medication",
+          "type": "string",
+          "required": false,
+          "enableWhen": [
+            {
+              "question": "4.1",
+              "operator": "=",
+              "answerBoolean": false
+            }
+          ],
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+              "valueExpression": {
+                "language": "text/cql",
+                "expression": "\"DrugHasREMSPrepopulation\".Meds"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "linkId": "5",
+      "type": "group",
+      "text": "Hepatic Medical History",
+      "item": [
+        {
+          "linkId": "5.1",
+          "text": "Check box in this section if there is no hepatic medical history",
+          "type": "boolean",
+          "required": false,
+          "initial": {
+            "value": false
+          }
+        },
+        {
+          "linkId": "5.2",
+          "text": "Check all that apply",
+          "type": "choice",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+              "valueExpression": {
+                "language": "text/cql",
+                "expression": "\"DrugHasREMSPrepopulation\".MedicalHistory"
+              }
+            }
+          ],
+          "required": true,
+          "repeats": true,
+          "enableWhen": [
+            {
+              "question": "5.1",
+              "operator": "=",
+              "answerBoolean": false
+            }
+          ],
+          "answerOption": [
+            {
+              "valueCoding": {
+                "code": "3738000",
+                "system": "http://snomed.info/sct",
+                "display": "Hepatitis Viral Status"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "85057007",
+                "system": "http://snomed.info/sct",
+                "display": "Hepatic Cyst"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "235877000",
+                "system": "http://snomed.info/sct",
+                "display": "Ischemic Hepatitis"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "15167005",
+                "system": "http://snomed.info/sct",
+                "display": "Alcohol Abuse"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "266902008",
+                "system": "http://snomed.info/sct",
+                "display": "Family History of Liver Disease"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "408335007",
+                "system": "http://snomed.info/sct",
+                "display": "Autoimmune Hepatitis"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "88518009",
+                "system": "http://snomed.info/sct",
+                "display": "Wilson’s Disease"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "26416006",
+                "system": "http://snomed.info/sct",
+                "display": "Drug Abuse"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "27503000",
+                "system": "http://snomed.info/sct",
+                "display": "Gilbert’s syndrome"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "363140000",
+                "system": "http://snomed.info/sct",
+                "display": "Hypolipoproteinemia"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "14783006",
+                "system": "http://snomed.info/sct",
+                "display": "Familial Hyperbilirubinemia"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "56882008",
+                "system": "http://snomed.info/sct",
+                "display": "Anorexia"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "105997008",
+                "system": "http://snomed.info/sct",
+                "display": "Biliary Tract Disorder"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "302870006",
+                "system": "http://snomed.info/sct",
+                "display": "Hypertriglyceridemia"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "19943007",
+                "system": "http://snomed.info/sct",
+                "display": "Cirrhosis"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "39621005",
+                "system": "http://snomed.info/sct",
+                "display": "Gallbladder Disease/ Gallstones/ Bile Duct Occlusion"
+              }
+            },
+            {
+              "valueCoding": {
+                "code": "73211009",
+                "system": "http://snomed.info/sct",
+                "display": "Diabetes"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "linkId": "6",
+      "type": "group",
+      "text": "Prescriber Agreement",
+      "item": [
+        {
+          "linkId": "6.1",
+          "text": "I have reviewed and discussed the risks of TURALIO and the requirements of the TURALIO REMS with this patient.",
+          "type": "display"
+        },
+        {
+          "linkId": "6.2",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/sub-questionnaire",
+              "valueCanonical": "questionnaire/provider-signature"
+            }
+          ],
+          "type": "display"
+        }
+      ]
+    },
+    {
+      "linkId": "7",
+      "type": "group",
+      "text": "Patient Attestation",
+      "item": [
+        {
+          "linkId": "7.1",
+          "text": "In order to receive TURALIO I must be enrolled in the TURALIO REMS. The TURALIO REMS will collect data to assess the risk of serious liver problems which can be severe and lead to death as described in the Patient Guide. \n • I agree to enroll in the Patient Registry. \n • I agree to review the Patient Guide. \n • I must get blood tests to test my liver as directed by my healthcare provider. \n • I agree to tell my healthcare provider if I have signs and/or symptoms of liver injury. \n • My personal information will be shared to enroll me in the Patient Registry so that my health and any liver injury can be evaluated while I am receiving TURALIO. \n • Daiichi Sankyo, Inc., and its agents, may contact me or my prescriber by phone, mail or email to manage the TURALIO REMS. \n • Daiichi Sankyo, Inc., and its agents, may use and share my personal health information, including lab tests and prescriptions as part of the TURALIO REMS. My information will be protected and will be used to enroll me into and manage the TURALIO REMS. My health information may be shared with the U.S. Food and Drug Administration (FDA) to evaluate the TURALIO REMS.",
+          "type": "display",
+          "readOnly": true
+        },
+        {
+          "linkId": "7.2",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/sub-questionnaire",
+              "valueCanonical": "questionnaire/patient-signature"
+            }
+          ],
+          "type": "display"
+        },
+        {
+          "linkId": "7.3",
+          "type": "attachment",
+          "text": "Upload Supplemental Files"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
introduces a rems database to the crd server, taking advantage of the hibernate database already in place.  Upon starting up the app, you should be able to visit `localhost:8090/rems/turalio` and receive back a json with one "requirement", which should be the questionnaire as a string.  

Currently there is no option to post a new requirement, this would probably require an operation that makes it simpler to produce requirements for a drug, and link it all together.  As of right now, the DatabaseInit class handles loading up the Turalio requirements. 

Right now the requirements are linked to a drug, and you can ask the database for drugs by id; in this case, the id is just "turalio", to keep things simple.  The requirement as of now are of type `RemsFhir`, which means they must be FHIR resources.  This can be changed if needed.  The general idea here is that you ask for a drug, you are given a bundle of requirements each with a boolean indicating whether the requirement is met, and theoretically the DTR app will be capable of figuring out the rest.

My inclination is that we can take advantage of the `Task`, `DocumentReference`, and `Questionnaire` resources to cover any requirements.  For example, many of the Turalio requirements could be captured as a `Task`, which most EHRs have workflows for already.