### PR TITLE
add doc links to cards

### DIFF
--- a/resources/src/main/java/org/cdshooks/CoverageRequirements.java
+++ b/resources/src/main/java/org/cdshooks/CoverageRequirements.java
@@ -1,5 +1,6 @@
 package org.cdshooks;
 
+import java.util.ArrayList;
 import java.util.UUID;
 
 public class CoverageRequirements {
@@ -7,22 +8,19 @@ public class CoverageRequirements {
   private String summary;
   private String details;
   private String infoLink;
-  private String questionnaireOrderUri;
-  private String questionnairePrescriberEnrollmentUri;
-  private String questionnairePrescriberKnowledgeAssessmentUri;
-  private String questionnaireFaceToFaceUri;
-  private String questionnaireLabUri;
-  private String questionnaireProgressNoteUri;
-  private String questionnairePARequestUri;
-  private String questionnairePlanOfCareUri;
-  private String questionnaireDispenseUri;
-  private String questionnaireAdditionalUri;
+  private ArrayList<Requirement> patientRequirements;
+  private ArrayList<Requirement> prescriberRequirements;
   private String requestId;
   private boolean priorAuthRequired;
   private boolean documentationRequired;
 
   private boolean priorAuthApproved;
   private String priorAuthId;
+
+  public CoverageRequirements() {
+    this.patientRequirements = new ArrayList<>();
+    this.prescriberRequirements = new ArrayList<>();
+  }
 
   public boolean getApplies() { return applies; }
 
@@ -33,6 +31,27 @@ public class CoverageRequirements {
 
   public String getSummary() {
     return summary;
+  }
+
+  public ArrayList<Requirement> getPatientRequirements() {
+    return patientRequirements;
+  }
+
+  public void addPatientRequirement(Requirement patientRequirement) {
+    if(patientRequirement.getUrl() != null) {
+      this.patientRequirements.add(patientRequirement);
+    }
+  }
+
+
+  public ArrayList<Requirement> getPrescriberRequirements() {
+    return prescriberRequirements;
+  }
+
+  public void addPrescriberRequirement(Requirement prescriberRequirement) {
+    if(prescriberRequirement.getUrl() != null) {
+      this.prescriberRequirements.add(prescriberRequirement);
+    }
   }
 
   public CoverageRequirements setSummary(String summary) {
@@ -55,86 +74,6 @@ public class CoverageRequirements {
 
   public CoverageRequirements setInfoLink(String infoLink) {
     this.infoLink = infoLink;
-    return this;
-  }
-  public String getQuestionnaireOrderUri() {
-    return questionnaireOrderUri;
-  }
-
-  public CoverageRequirements setQuestionnaireOrderUri(String questionnaireOrderUri) {
-    this.questionnaireOrderUri = questionnaireOrderUri;
-    return this;
-  }
-
-  public String getQuestionnaireFaceToFaceUri() {
-    return this.questionnaireFaceToFaceUri;
-  }
-
-  public CoverageRequirements setQuestionnairePrescriberEnrollmentUri(String questionnairePrescriberEnrollmentUri) {
-    this.questionnairePrescriberEnrollmentUri = questionnairePrescriberEnrollmentUri;
-    return this;
-  }
-
-  public String getQuestionnairePrescriberEnrollmentUri() {
-    return this.questionnairePrescriberEnrollmentUri;
-  }
-
-  public CoverageRequirements setQuestionnairePrescriberKnowledgeAssessmentUri(String questionnairePrescriberKnowledgeAssessmentUri) {
-    this.questionnairePrescriberKnowledgeAssessmentUri = questionnairePrescriberKnowledgeAssessmentUri;
-    return this;
-  }
-
-  public String getQuestionnairePrescriberKnowledgeAssessmentUri() {
-    return this.questionnairePrescriberKnowledgeAssessmentUri;
-  }
-
-  public CoverageRequirements setQuestionnaireFaceToFaceUri(String questionnaireFaceToFaceUri) {
-    this.questionnaireFaceToFaceUri = questionnaireFaceToFaceUri;
-    return this;
-  }
-
-  public String getQuestionnaireLabUri() {
-    return questionnaireLabUri;
-  }
-
-  public CoverageRequirements setQuestionnaireLabUri(String questionnaireLabUri) {
-    this.questionnaireLabUri = questionnaireLabUri;
-    return this;
-  }
-
-  public String getQuestionnaireProgressNoteUri() {
-    return questionnaireProgressNoteUri;
-  }
-
-  public CoverageRequirements setQuestionnaireProgressNoteUri(String questionnaireProgressNoteUri) {
-    this.questionnaireProgressNoteUri = questionnaireProgressNoteUri;
-    return this;
-  }
-
-  public String getQuestionnairePARequestUri() {
-    return questionnairePARequestUri;
-  }
-
-  public CoverageRequirements setQuestionnairePARequestUri(String questionnairePARequestUri) {
-    this.questionnairePARequestUri = questionnairePARequestUri;
-    return this;
-  }
-
-  public String getQuestionnairePlanOfCareUri() {
-    return questionnairePlanOfCareUri;
-  }
-
-  public CoverageRequirements setQuestionnairePlanOfCareUri(String questionnairePlanOfCareUri) {
-    this.questionnairePlanOfCareUri = questionnairePlanOfCareUri;
-    return this;
-  }
-
-  public String getQuestionnaireDispenseUri() {
-    return questionnaireDispenseUri;
-  }
-
-  public CoverageRequirements setQuestionnaireDispenseUri(String questionnaireDispenseUri) {
-    this.questionnaireDispenseUri = questionnaireDispenseUri;
     return this;
   }
 
@@ -185,11 +124,4 @@ public class CoverageRequirements {
     return this;
   }
 
-  public String getQuestionnaireAdditionalUri() {
-    return questionnaireAdditionalUri;
-  }
-
-  public void setQuestionnaireAdditionalUri(String questionnaireAdditionalUri) {
-    this.questionnaireAdditionalUri = questionnaireAdditionalUri;
-  }
 }

--- a/resources/src/main/java/org/cdshooks/Requirement.java
+++ b/resources/src/main/java/org/cdshooks/Requirement.java
@@ -1,0 +1,51 @@
+package org.cdshooks;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Requirement {
+
+    private String url;
+    private String label;
+    private String type;
+    static final Logger logger = LoggerFactory.getLogger(Requirement.class);
+
+    public Requirement(Object url, String label, String type) {
+        if(url != null) {
+            this.url = url.toString();
+        } else {
+            logger.info(String.format("-- No %s defined",label));
+            this.url = null;
+        }
+        this.label = label;
+        this.type = type;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(Object url) {
+        if(url != null){
+            this.url = url.toString();
+        }
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+
+}


### PR DESCRIPTION
Changes to work with the CDS-Library pull request of the same name.  The way the doc links were being handled currently were giving off a bad code smell so I overhauled it and now it should be simpler to add more links in the future and create new REMS rules.  

I didn't change the questionnaires though, since I didn't want to have to change every single rule file to comply with the new method in the code, but in the future it should be possible to do the same thing for Questionnaires as is done for the info links.  

The basic idea is to put things in lists instead of individually grabbing them from the CQL, which would require a new couple of lines for every unique CQL definition name.  